### PR TITLE
Add API endpoint to check if call prefix exists

### DIFF
--- a/CallProcess.Application/Features/CallPrefixes/Queries/CheckCallPrefixExistsHandler.cs
+++ b/CallProcess.Application/Features/CallPrefixes/Queries/CheckCallPrefixExistsHandler.cs
@@ -1,0 +1,20 @@
+using CacheManagement.Interface;
+using CallProcess.Domain.Common;
+
+namespace CallProcess.Application.Features.CallPrefixes.Queries
+{
+    public class CheckCallPrefixExistsHandler
+    {
+        private readonly ICacheService _cacheService;
+
+        public CheckCallPrefixExistsHandler(ICacheService cacheService)
+        {
+            _cacheService = cacheService;
+        }
+
+        public async Task<bool> Handle(CheckCallPrefixExistsQuery query)
+        {
+            return await _cacheService.HashFieldExistsAsync(CacheHelper.CountryCodeKey, query.Code);
+        }
+    }
+}

--- a/CallProcess.Application/Features/CallPrefixes/Queries/CheckCallPrefixExistsQuery.cs
+++ b/CallProcess.Application/Features/CallPrefixes/Queries/CheckCallPrefixExistsQuery.cs
@@ -1,0 +1,12 @@
+namespace CallProcess.Application.Features.CallPrefixes.Queries
+{
+    public class CheckCallPrefixExistsQuery
+    {
+        public string Code { get; }
+
+        public CheckCallPrefixExistsQuery(string code)
+        {
+            Code = code;
+        }
+    }
+}

--- a/CallProcess.Application/Features/CallPrefixes/Queries/GetCallPrefixByCodeQuery.cs
+++ b/CallProcess.Application/Features/CallPrefixes/Queries/GetCallPrefixByCodeQuery.cs
@@ -2,7 +2,7 @@
 {
     public class GetCallPrefixByCodeQuery
     {
-        public string Code { get; set; }
+        public string Code { get; }
 
         public GetCallPrefixByCodeQuery(string code)
         {

--- a/CallProcess.WebApi/Controllers/CallPrefixController.cs
+++ b/CallProcess.WebApi/Controllers/CallPrefixController.cs
@@ -2,6 +2,7 @@
 using CallProcess.Application.Features.CallPrefixes.Queries;
 using CallProcess.Domain.Entities.CallPrefix;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace CallProcess.WebApi.Controllers
 {
@@ -13,24 +14,32 @@ namespace CallProcess.WebApi.Controllers
 
         private readonly GetAllCallPrefixesHandler _getAllHandler;
         
+        private readonly CheckCallPrefixExistsHandler _existsHandler;
+
         private readonly GetCallPrefixByCodeHandler _getByCodeHandler;
         
         private readonly AddOrUpdateCallPrefixHandler _addOrUpdateHandler;
         
         private readonly DeleteCallPrefixHandler _deleteHandler;
 
+        private readonly ILogger<CallPrefixController> _logger;
+
         #endregion
 
         public CallPrefixController(
             GetAllCallPrefixesHandler getAllHandler,
+            CheckCallPrefixExistsHandler existsHandler,
             GetCallPrefixByCodeHandler getByCodeHandler,
             AddOrUpdateCallPrefixHandler addOrUpdateHandler,
-            DeleteCallPrefixHandler deleteHandler)
+            DeleteCallPrefixHandler deleteHandler,
+            ILogger<CallPrefixController> logger)
         {
             _getAllHandler = getAllHandler;
+            _existsHandler = existsHandler;
             _getByCodeHandler = getByCodeHandler;
             _addOrUpdateHandler = addOrUpdateHandler;
             _deleteHandler = deleteHandler;
+            _logger = logger;
         }
 
         #region Api Methods
@@ -41,6 +50,20 @@ namespace CallProcess.WebApi.Controllers
         {
             var result = await _getAllHandler.Handle(new GetAllCallPrefixesQuery());
             return Ok(result);
+        }
+
+        // GET: api/callprefix/exists?code=91
+        [HttpGet("ExistsByCode")]
+        public async Task<ActionResult<bool>> ExistsByCode([FromQuery] string code)
+        {
+            if (string.IsNullOrWhiteSpace(code))
+            {
+                _logger.LogWarning("ExistsByCode request rejected due to missing code.");
+                return BadRequest("Code is required.");
+            }
+
+            var exists = await _existsHandler.Handle(new CheckCallPrefixExistsQuery(code));
+            return Ok(exists);
         }
 
         // GET: api/callprefix/{prefix}

--- a/CallProcess.WebApi/Program.cs
+++ b/CallProcess.WebApi/Program.cs
@@ -13,6 +13,7 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddSingleton<ICallPrefixRepository, InMemoryCallPrefixRepository>();
+builder.Services.AddScoped<CheckCallPrefixExistsHandler>();
 builder.Services.AddScoped<GetAllCallPrefixesHandler>();
 builder.Services.AddScoped<GetCallPrefixByCodeHandler>();
 builder.Services.AddScoped<AddOrUpdateCallPrefixHandler>();


### PR DESCRIPTION
### Motivation
- Provide a lightweight API to validate whether a given country/call code exists in the cache without returning the full record.
- Keep query DTOs immutable to reduce accidental mutation and improve thread-safety.
- Wire the new handler into DI and expose the endpoint for callers (e.g. front-end or other services) to quickly validate codes.

### Description
- Added `CheckCallPrefixExistsQuery` and `CheckCallPrefixExistsHandler` which call `ICacheService.HashFieldExistsAsync` against `CacheHelper.CountryCodeKey` to determine existence.
- Exposed a new controller endpoint `ExistsByCode` (`GET api/callprefix/ExistsByCode?code=...`) which validates input, logs a warning for missing code, and returns a boolean result via the new handler.
- Registered the new handler in DI by adding `builder.Services.AddScoped<CheckCallPrefixExistsHandler>();` to `Program.cs` and injected it plus an `ILogger<CallPrefixController>` into `CallPrefixController`.
- Made `GetCallPrefixByCodeQuery` immutable by changing `Code` to a get-only property.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698350c56c14832483d3949a00a99b33)